### PR TITLE
Fix for outerdiv size bug

### DIFF
--- a/assets/bower_components/three-js/three-js.html
+++ b/assets/bower_components/three-js/three-js.html
@@ -47,7 +47,11 @@
           Polymer.dom(this.root).appendChild(renderer.domElement);
           this.renderer = renderer;
           var parent = Polymer.dom(this).parentNode;
-          renderer.setSize(parent.clientWidth, parent.clientHeight);
+          if (typeof parent.clientWidth === "undefined" || typeof parent.clientHeight === "undefined") {
+            renderer.setSize(1000, 562);
+          } else {
+            renderer.setSize(parent.clientWidth, parent.clientHeight);
+          }
           //renderer.shadowMapEnabled = true;
           //renderer.shadowMapType = THREE.PCFShadowMap;
           renderer.setClearColor(this.bgcolor);

--- a/assets/bower_components/three-js/three-js.html
+++ b/assets/bower_components/three-js/three-js.html
@@ -33,14 +33,6 @@
         Polymer({
           is: 'three-js',
           properties: {
-            w: {
-                type: String,
-                value: "1000"
-            },
-            h: {
-                type: String,
-                value: "562"
-            },
             bgcolor: {
               type: String,
               value: "#ffffff",
@@ -54,7 +46,8 @@
           });
           Polymer.dom(this.root).appendChild(renderer.domElement);
           this.renderer = renderer;
-          renderer.setSize(this.w, this.h);
+          var parent = Polymer.dom(this).parentNode;
+          renderer.setSize(parent.clientWidth, parent.clientHeight);
           //renderer.shadowMapEnabled = true;
           //renderer.shadowMapType = THREE.PCFShadowMap;
           renderer.setClearColor(this.bgcolor);

--- a/src/ThreeJS.jl
+++ b/src/ThreeJS.jl
@@ -11,7 +11,7 @@ include("properties.jl")
 
 "Outer div to keep the three-js tag in."
 function outerdiv(w::AbstractString="100%", h::AbstractString="600px")
-    Elem(:div, id="three-js-div", style=Dict(:width=>w, :height=>h))
+    Elem(:div, style=Dict(:width=>w, :height=>h))
 end
 
 "Initiates a three-js scene"

--- a/src/ThreeJS.jl
+++ b/src/ThreeJS.jl
@@ -11,7 +11,7 @@ include("properties.jl")
 
 "Outer div to keep the three-js tag in."
 function outerdiv(w::AbstractString="100%", h::AbstractString="600px")
-    Elem(:div, style=Dict(:width=>w, :height=>h))
+    Elem(:div, id="three-js-div", style=Dict(:width=>w, :height=>h))
 end
 
 "Initiates a three-js scene"


### PR DESCRIPTION
The function `ThreeJS.outerdiv` currently does not set the size properly. This PR fixes that bug. The details are as follows:

It's pretty well-known that the ThreeJS renderer interacts a little strangely with the div it's contained in, see https://www.quora.com/What-is-a-good-way-to-put-ThreeJS-into-a-Div for instance. The best strategy I've found is to force the renderer to always be exactly the size of its enclosing div by appropriate calls to `renderer.setSize`. This wasn't being done before, now it is.

It's likely still possible that there are ways to resize the enclosing div that won't resize the renderer, but this PR is a good start. It fixes https://github.com/rohitvarkey/ThreeJS.jl/issues/37.
