### PR TITLE
Refactored three-js-box to use an observer of multiple properties

### DIFF
--- a/assets/bower_components/three-js/three-js.html
+++ b/assets/bower_components/three-js/three-js.html
@@ -475,47 +475,32 @@
     Polymer({
       is: 'three-js-box',
       properties: {
-        d: {
+        width: {
           type: Number,
           value: 100,
-          notify: true,
-          observer: 'newGeo'
         },
-        extent: {
-          type: Number,
-          value: 0,
-          notify: true,
-          observer: 'extentChanged'
-        },
-        h: {
+        height: {
           type: Number,
           value: 100,
-          notify: true,
-          observer: 'newGeo'
         },
-        w: {
+        depth: {
           type: Number,
           value: 100,
-          notify: true,
-          observer: 'newGeo'
         }
       },
+      observers: [
+        'parametersChanged(width, height, depth)'
+      ],
       attached: function () {
-        this.extentChanged();
         this.async(function() {
-          this.newGeo();
+          this.parametersChanged();
         });
       },
-      extentChanged: function () {
-        if (this.extent) {
-          this.w = this.h = this.d = this.extent;
-        }
-      },
-      newGeo: function () {
-        //console.log("New Geo called");
-        this.object = new THREE.BoxGeometry(this.w, this.h, this.d);
-        if(Polymer.dom(this).parentNode)
+      parametersChanged: function(width, height, depth) {
+        this.object = new THREE.BoxGeometry(width, height, depth);
+        if (Polymer.dom(this).parentNode) {
           Polymer.dom(this).parentNode.addGeom(this.object);
+        }
       }
     });
   </script>

--- a/examples/box.jl
+++ b/examples/box.jl
@@ -1,4 +1,4 @@
-import ThreeJS 
+import ThreeJS
 
 main(window) =  begin
     push!(window.assets,("ThreeJS","threejs"))
@@ -31,10 +31,10 @@ main(window) =  begin
         ),
         vskip(2em),
         map(w, h, d, rx, ry, rz, o) do w, h, d, rx, ry, rz, o
-        ThreeJS.outerdiv() << 
+        ThreeJS.outerdiv() <<
             (ThreeJS.initscene() <<
                 [
-                    ThreeJS.mesh(0.0, 0.0, 0.0, rx = rx, ry = ry, rz = rz) << 
+                    ThreeJS.mesh(0.0, 0.0, 0.0, rx = rx, ry = ry, rz = rz) <<
                     [
                         ThreeJS.box(w, h, d), ThreeJS.material(Dict(:kind=>"lambert",:color=>"red", :transparent=>true, :opacity=>o))
                     ],

--- a/examples/rotatingcube.jl
+++ b/examples/rotatingcube.jl
@@ -1,6 +1,6 @@
 #Run this in Escher to see a rotating cube in the browser.
 
-import ThreeJS 
+import ThreeJS
 
 main(window) =  begin
     push!(window.assets,("ThreeJS","threejs"))
@@ -12,10 +12,10 @@ main(window) =  begin
         rx += 0.5
         ry += 0.5
         rz += 0.5
-        ThreeJS.outerdiv() << 
+        ThreeJS.outerdiv() <<
                 (ThreeJS.initscene() <<
                     [
-                        ThreeJS.mesh(0.0, 0.0, 0.0; rx=rx, ry=ry, rz=rz) << 
+                        ThreeJS.mesh(0.0, 0.0, 0.0; rx=rx, ry=ry, rz=rz) <<
                         [
                             ThreeJS.box(5.0, 5.0, 5.0), ThreeJS.material(Dict(:kind=>"phong",:color=>"red"))
                         ],

--- a/src/render.jl
+++ b/src/render.jl
@@ -29,11 +29,11 @@ function mesh(
 end
 
 """
-Creates a Box geometry of width `w`, height `h` and depth `d`.
+Creates a Box geometry of `width`, `height` and `depth`.
 Should be put in a `mesh` along with another material Elem to render.
 """
-function box(w::Float64,h::Float64,d::Float64)
-   Elem(:"three-js-box", attributes = Dict(:width=>w, :height=>h, :depth=>d))
+function box(width::Real, height::Real, depth::Real)
+   Elem(:"three-js-box", attributes = Dict(:width=>width, :height=>height, :depth=>depth))
 end
 
 """

--- a/src/render.jl
+++ b/src/render.jl
@@ -33,7 +33,7 @@ Creates a Box geometry of width `w`, height `h` and depth `d`.
 Should be put in a `mesh` along with another material Elem to render.
 """
 function box(w::Float64,h::Float64,d::Float64)
-   Elem(:"three-js-box", attributes = Dict(:w=>w, :h=>h, :d=>d))
+   Elem(:"three-js-box", attributes = Dict(:width=>w, :height=>h, :depth=>d))
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,7 +63,7 @@ facts("Testing Render Elem Outputs") do
         @fact box(10.0, 11.0, 12.0) -->
             Elem(
                 :"three-js-box",
-                attributes = Dict(:w => 10.0, :h => 11.0, :d => 12.0)
+                attributes = Dict(:width => 10.0, :height => 11.0, :depth => 12.0)
             )
         @fact sphere(10.0) -->
             Elem(:"three-js-sphere", attributes = Dict(:r => 10.0))


### PR DESCRIPTION
This PR changes three-js-box so that it uses a single observer on its `width`, `height`, and `depth` properties. I've also cleaned it up a bit, removing an unused property `extent` and renaming things to match their ThreeJS names.

Both @rohitvarkey and I found that more complex observers, like observers on multiple properties, weren't working before. But apparently they are now. I'd like to slowly migrate things to use observers like that, as it would be much more efficient.

There is a secondary problem here that I have not solved. If we use something like `ThreeJS.box` from Julia, a new box will be constructed on the JavaScript side every time (say) either the width or the height changes. If we change them both at the same time, we construct the box twice.

That problem probably needs to be fixed on the Julia side. One option would be putting all the parameters in a `Dict` and serializing that, with the side effect that those parameters could no longer be attributes. Another option would be to encourage the use of `scale` from ThreeJS instead.
