### PR TITLE
Fixed resizing bug, made aspect ratio of camera default to renderer aspect ratio

### DIFF
--- a/examples/rotatingcube.jl
+++ b/examples/rotatingcube.jl
@@ -19,9 +19,9 @@ main(window) =  begin
                         [
                             ThreeJS.box(5.0, 5.0, 5.0), ThreeJS.material(Dict(:kind=>"phong",:color=>"red"))
                         ],
-                        ThreeJS.pointlight(10.0, 10.0, 10.0),
-                        ThreeJS.pointlight(-10.0, -10.0, -10.0),
-                        ThreeJS.camera(0.0, 0.0, 20.0)
+                        ThreeJS.pointlight(150.0, 150.0, 150.0),
+                        ThreeJS.pointlight(-150.0, -150.0, -150.0),
+                        ThreeJS.camera(0.0, 0.0, 250.0)
                     ]
                 )
         end

--- a/src/ThreeJS.jl
+++ b/src/ThreeJS.jl
@@ -11,7 +11,7 @@ include("properties.jl")
 
 "Outer div to keep the three-js tag in."
 function outerdiv(w::AbstractString="100%", h::AbstractString="600px")
-    Elem(:div, style=Dict(:width=>w, :height=>h, ))
+    Elem(:div, style=Dict(:width=>w, :height=>h))
 end
 
 "Initiates a three-js scene"

--- a/src/ThreeJS.jl
+++ b/src/ThreeJS.jl
@@ -11,7 +11,7 @@ include("properties.jl")
 
 "Outer div to keep the three-js tag in."
 function outerdiv(w::AbstractString="100%", h::AbstractString="600px")
-    Elem(:div, style=Dict(:width=>w, :height=>h))
+    Elem(:div, style=Dict(:width=>w, :height=>h, ))
 end
 
 "Initiates a three-js scene"

--- a/src/render.jl
+++ b/src/render.jl
@@ -280,15 +280,15 @@ function camera(
     y::Float64,
     z::Float64;
     fov::Float64=45.0,
-    aspect::Float64=16/9,
-    near::Float64=0.1,
-    far::Float64=10000.0
+    aspect=nothing,
+    near::Float64=1.0,
+    far::Float64=1000.0
     )
     Elem(
         :"three-js-camera",
         attributes = Dict(
             :x => x, :y => y,:z => z,
-            :fov => fov,:aspect => aspect, :near => near, :far => far
+            :fov => fov, :aspect => aspect, :near => near, :far => far
         )
     )
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -240,9 +240,9 @@ facts("Testing Render Elem Outputs") do
                     :y => 11.0,
                     :z => 12.0,
                     :fov => 45.0,
-                    :aspect => 16/9,
-                    :near => 0.1,
-                    :far => 10000.0
+                    :aspect => nothing,
+                    :near => 1.0,
+                    :far => 1000.0
                 )
             )
     end


### PR DESCRIPTION
This PR is essentially a follow-on to https://github.com/rohitvarkey/ThreeJS.jl/pull/38. What was going on there was that the renderer was simply always expanding to some very large default size, and it was not resizable -- so it could not be in layouts, etc.

I fixed that bug, but it led to some strangeness in other places. For one, the camera aspect ratio was always set at `16 / 9`. I have changed this so that the camera aspect ratio now defaults to the the aspect ratio of the renderer in which it is contained (probably what most people want), though an explicit aspect ratio can still be passed in.

As a consequence of the above and the earlier PR, the camera and lighting in the examples needs to be slightly readjusted. I have done so for rotatingcube.jl, which is nicely doing what it was before but with an aspect ratio of the renderer window and the renderer window being set to a sensible size. The other examples will follow.

The accompanying PR is https://github.com/rohitvarkey/three-js/pull/8.
