### PR TITLE
[WIP] Emulation of 3D textures

### DIFF
--- a/examples/assets/compressedtexture.vert
+++ b/examples/assets/compressedtexture.vert
@@ -1,0 +1,6 @@
+varying vec2 v_uv;
+
+void main() {
+  v_uv = uv;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}

--- a/examples/assets/emulatedtexture3D.frag
+++ b/examples/assets/emulatedtexture3D.frag
@@ -3,25 +3,4 @@ uniform float w;
 
 uniform sampler2D data;
 
-vec4 texture2DAs3D(sampler2D tex, vec3 texcoord) {
-    vec3 shape = vec3(512.0, 512.0, 2.0);
-    float r = 1.0;
-    float c = 2.0;
-
-    // Don't let adjacent frames be interpolated into this one
-    texcoord.x = min(texcoord.x * shape.x, shape.x - 0.5);
-    texcoord.x = max(0.5, texcoord.x) / shape.x;
-
-    texcoord.y = min(texcoord.y * shape.y, shape.y - 0.5);
-    texcoord.y = max(0.5, texcoord.y) / shape.y;
-
-    float index = floor(texcoord.z * shape.z);
-
-    // Do a lookup in the 2D texture
-    float u = (mod(index, r) + texcoord.x) / r;
-    float v = (floor(index / r) + texcoord.y) / c;
-
-    return texture2D(tex, vec2(u, v));
-}
-
 void main() { gl_FragColor = texture2DAs3D(data, vec3(v_uv, w)); }

--- a/examples/assets/emulatedtexture3D.frag
+++ b/examples/assets/emulatedtexture3D.frag
@@ -1,0 +1,27 @@
+varying vec2 v_uv;
+uniform float w;
+
+uniform sampler2D data;
+
+vec4 texture2DAs3D(sampler2D tex, vec3 texcoord) {
+    vec3 shape = vec3(512.0, 512.0, 2.0);
+    float r = 1.0;
+    float c = 2.0;
+
+    // Don't let adjacent frames be interpolated into this one
+    texcoord.x = min(texcoord.x * shape.x, shape.x - 0.5);
+    texcoord.x = max(0.5, texcoord.x) / shape.x;
+
+    texcoord.y = min(texcoord.y * shape.y, shape.y - 0.5);
+    texcoord.y = max(0.5, texcoord.y) / shape.y;
+
+    float index = floor(texcoord.z * shape.z);
+
+    // Do a lookup in the 2D texture
+    float u = (mod(index, r) + texcoord.x) / r;
+    float v = (floor(index / r) + texcoord.y) / c;
+
+    return texture2D(tex, vec2(u, v));
+}
+
+void main() { gl_FragColor = texture2DAs3D(data, vec3(v_uv, w)); }

--- a/examples/emulatedtexture3D.jl
+++ b/examples/emulatedtexture3D.jl
@@ -1,0 +1,38 @@
+import ThreeJS
+import FileIO: load
+import Reactive: every
+
+ascent = load("assets/ascent.png")
+a = reinterpret(UInt8, ascent.data)
+
+# 1024
+#depth, width = 512, 512
+#r = 1024 // width
+#c = depth // r
+#if math.fmod(depth, r):
+#    c += 1
+
+main(window) =  begin
+    push!(window.assets,("ThreeJS","threejs"))
+    push!(window.assets,"nested-props")
+
+    b = Array{UInt8}(512, 512, 2)
+    b[:, :, 1] = a[:, :] * 0.0
+    b[:, :, 2] = a[:, :] * 1.0
+    println(typeof(b))
+    println(size(b))
+
+    ThreeJS.outerdiv() <<
+    (ThreeJS.initscene() <<
+        [
+            ThreeJS.mesh(0.0, 0.0, 0.0) <<
+            [
+                ThreeJS.plane(512.0, 512.0),
+                ThreeJS.shadermaterial(open(readall, "assets/compressedtexture.vert", "r"), open(readall, "assets/emulatedtexture3D.frag", "r");
+                        :uniforms => Dict(:w => Dict(:type => "f", :value => 0.2))) <<
+                    ThreeJS.datatexture("data", b)
+            ],
+            ThreeJS.camera(0.0, 0.0, 768.0)
+        ]
+    )
+end

--- a/examples/emulatedtexture3D.jl
+++ b/examples/emulatedtexture3D.jl
@@ -2,8 +2,8 @@ import ThreeJS
 import FileIO: load
 import Reactive: every
 
-ascent = load("assets/ascent.png")
-a = reinterpret(UInt8, ascent.data)
+#ascent = load("assets/ascent.png")
+#a = reinterpret(UInt8, ascent.data)
 
 # 1024
 #depth, width = 512, 512
@@ -12,27 +12,83 @@ a = reinterpret(UInt8, ascent.data)
 #if math.fmod(depth, r):
 #    c += 1
 
+function emulated_size(width, height, depth)
+    gl_max_texture_size = 1024
+
+    r = div(gl_max_texture_size, height)
+    c = div(width, r)
+
+    if mod(width, r) != 0
+        c += 1
+    end
+
+    1, 4
+end
+
+n = 4
+
+a = Array(UInt8, 64, 64, n)
+println(strides(a))
+println(emulated_size(size(a)...))
+
+for k in 1:n
+    j = round(Int, k / n * size(a, 2))
+    a[:, 1:j, k] = 128
+    a[:, j:size(a, 2), k] = 0
+end
+
+
+function texture2DAs3D(width::Real, height::Real, depth::Real, name = "texture2DAs3D")
+    r = 1.0
+    c = 4.0
+
+    """
+        vec4 $name(sampler2D tex, vec3 texcoord) {
+            vec3 shape = vec3($width, $height, $depth);
+
+            // Don't let adjacent frames be interpolated into this one
+            texcoord.x = min(texcoord.x * shape.x, shape.x - 0.5);
+            texcoord.x = max(0.5, texcoord.x) / shape.x;
+
+            texcoord.y = min(texcoord.y * shape.y, shape.y - 0.5);
+            texcoord.y = max(0.5, texcoord.y) / shape.y;
+
+            float index = floor(texcoord.z * shape.z);
+
+            // Do a lookup in the 2D texture
+            float u = (mod(index, $r) + texcoord.x) / $r;
+            float v = (floor(index / $r) + texcoord.y) / $c;
+
+            return texture2D(tex, vec2(u, v));
+        }
+    """
+end
+
 main(window) =  begin
     push!(window.assets,("ThreeJS","threejs"))
     push!(window.assets,"nested-props")
 
-    b = Array{UInt8}(512, 512, 2)
-    b[:, :, 1] = a[:, :] * 0.0
-    b[:, :, 2] = a[:, :] * 1.0
-    println(typeof(b))
-    println(size(b))
+    frag = string(texture2DAs3D(size(a)...), open(readall, "assets/emulatedtexture3D.frag", "r"))
 
-    ThreeJS.outerdiv() <<
-    (ThreeJS.initscene() <<
-        [
-            ThreeJS.mesh(0.0, 0.0, 0.0) <<
+    i = 0
+    map(every(1)) do _
+        i += 1
+        if (i > size(a, 3))
+            i = 1
+        end
+
+        ThreeJS.outerdiv() <<
+        (ThreeJS.initscene() <<
             [
-                ThreeJS.plane(512.0, 512.0),
-                ThreeJS.shadermaterial(open(readall, "assets/compressedtexture.vert", "r"), open(readall, "assets/emulatedtexture3D.frag", "r");
-                        :uniforms => Dict(:w => Dict(:type => "f", :value => 0.2))) <<
-                    ThreeJS.datatexture("data", b)
-            ],
-            ThreeJS.camera(0.0, 0.0, 768.0)
-        ]
-    )
+                ThreeJS.mesh(0.0, 0.0, 0.0) <<
+                [
+                    ThreeJS.plane(size(a, 1), size(a, 2)),
+                    ThreeJS.shadermaterial(open(readall, "assets/compressedtexture.vert", "r"), frag;
+                            :uniforms => Dict(:w => Dict(:type => "f", :value => i / size(a, 3)))) <<
+                        ThreeJS.datatexture("data", a)
+                ],
+                ThreeJS.camera(0.0, 0.0, 768.0)
+            ]
+        )
+    end
 end

--- a/src/render.jl
+++ b/src/render.jl
@@ -516,7 +516,7 @@ function datatexture(name::ASCIIString, data::Array{UInt8, 2}; kwds...)
 end
 
 function datatexture(name::AbstractString, data::Array{UInt8, 3}; kwds...)
-    datatexture(name, base64encode(data), 512, 1024; :format => "LuminanceFormat", :type => "UnsignedByteType", kwds...)
+    datatexture(name, base64encode(data), 64 * 1, 64 * 4; :format => "LuminanceFormat", :type => "UnsignedByteType", kwds...)
 end
 
 """

--- a/src/render.jl
+++ b/src/render.jl
@@ -515,6 +515,9 @@ function datatexture(name::ASCIIString, data::Array{UInt8, 2}; kwds...)
         :format => "LuminanceFormat", :type => "UnsignedByteType", kwds...)
 end
 
+function datatexture(name::AbstractString, data::Array{UInt8, 3}; kwds...)
+    datatexture(name, base64encode(data), 512, 1024; :format => "LuminanceFormat", :type => "UnsignedByteType", kwds...)
+end
 
 """
 Creates a point cloud tag.


### PR DESCRIPTION
The current specification of WebGL doesn't support 3D textures. This PR adds emulated 3D textures, by sending them to the GPU as a 2D texture and providing an appropriate look-up function.

This is based off of work that I and others did in VisPy, see https://github.com/vispy/vispy/blob/73ff8851c005a1c678dbf5879a7dbf3fc2747f9a/vispy/gloo/texture.py
